### PR TITLE
Allow docker url list to be a string

### DIFF
--- a/screen/07-CustomScript.go
+++ b/screen/07-CustomScript.go
@@ -93,7 +93,7 @@ func prepareEnvironment() {
 
 func selectDockerURL() {
 	selectURL, _ := pterm.DefaultInteractiveSelect.
-		WithOptions(dockerURL).
+		WithOptions(strings.Split(dockerURLs, "*")).
 		Show("Please select docker URL")
 
 	_, err_int := global.ExecCommand("mkdir", "-p", filepath.Dir(mountPoint+dockerURLPath))

--- a/screen/screens.go
+++ b/screen/screens.go
@@ -33,7 +33,7 @@ var envPath = "./.env"
 var networkInterface = ""
 
 // Docker URL selections
-var dockerURL = []string{"ghcr.io", "cr.airoplatform.com"}
+var dockerURLs = "ghcr.io*cr.airoplatform.com"
 var dockerURLPath = "/var/fogdata/cr.url"
 
 func GetCurrentScreen() int {


### PR DESCRIPTION
- List of docker urls is now a string, separator *